### PR TITLE
[Feat] 스킬데이터 추가와 몬스터 데이터 추가

### DIFF
--- a/Assets/Scripts/Data/GameData/DataSetter.cs
+++ b/Assets/Scripts/Data/GameData/DataSetter.cs
@@ -10,10 +10,12 @@ public class DataSetter : MonoBehaviour
     private PoolData poolData;
     private MonsterDataBase monsterDataBase;
     private PlayerLevelData playerLevelData;
+    private SkillDataBase skillDataBase;
 
     const string poolRange = "A2:B3";
     const string monsterRange = "A2:D4";
     const string levelDataRange = "A2:B18";
+    const string skillDataRange = "";
 
     #region URL
     // URL : https://docs.google.com/spreadsheets/d/1rqimYysZfUS9PuEodI6qOfoqEmX-2pi6TSmnBiJM810
@@ -22,8 +24,10 @@ public class DataSetter : MonoBehaviour
 
     // guid 1001143924
     string MonsterURL = $"https://docs.google.com/spreadsheets/d/1rqimYysZfUS9PuEodI6qOfoqEmX-2pi6TSmnBiJM810/export?format=tsv&gid=1001143924&range={monsterRange}";
-
+    // guid 2123442088
     string levelURL = $"https://docs.google.com/spreadsheets/d/1rqimYysZfUS9PuEodI6qOfoqEmX-2pi6TSmnBiJM810/export?format=tsv&gid=2123442088&range={levelDataRange}";
+    // guid 871025501
+    string skillURL = $"https://docs.google.com/spreadsheets/d/1rqimYysZfUS9PuEodI6qOfoqEmX-2pi6TSmnBiJM810/export?format=tsv&gid=871025501&range={levelDataRange}";
 
     #endregion
 
@@ -32,10 +36,12 @@ public class DataSetter : MonoBehaviour
         poolData = Manager.Pool.poolData;
         monsterDataBase = Manager.Data.monsterData;
         playerLevelData = Manager.Data.playerStatus.levelExpData;
-        
+        skillDataBase = Manager.Data.skillData;
+
         StartCoroutine(DownloadData(PoolURL, DataType.Pool));
         StartCoroutine(DownloadData(MonsterURL, DataType.Monster));
         StartCoroutine(DownloadData(levelURL, DataType.Level));
+        StartCoroutine(DownloadData(skillURL, DataType.Skill));
     }
 
     IEnumerator DownloadData(string URL, DataType type)
@@ -53,6 +59,10 @@ public class DataSetter : MonoBehaviour
                 SetupMonsterData(data); break;
             case DataType.Level:
                 SetupLevelData(data); break;
+            case DataType.Skill:
+                SetupSkillData(data); break;
+            default:
+                break;
         }
     }
 
@@ -81,10 +91,13 @@ public class DataSetter : MonoBehaviour
             string[] columns = row[i].Split("\t");
             MonsterData md = new MonsterData
             {
-                name = columns[0],
-                health = int.Parse(columns[1]),
-                damage = int.Parse(columns[2]),
-                speed = float.Parse(columns[3])
+                name    = columns[0],
+                health  = int.Parse(columns[1]),
+                damage  = int.Parse(columns[2]),
+                speed   = float.Parse(columns[3]),
+                dropGold = int.Parse(columns[4]),
+                dropExp = int.Parse(columns[5]),
+                range   = float.Parse(columns[6]),
             };
 
             monsterDataBase.AddMonsterData(
@@ -106,6 +119,22 @@ public class DataSetter : MonoBehaviour
             string[] columns = row[i].Split('\t');
 
             playerLevelData.AddLevelExpData(int.Parse(columns[0]), int.Parse(columns[1]));
+        }
+    }
+
+    private void SetupSkillData(string data)
+    {
+        string[] row = data.Split("\n");
+        int rowSize = row.Length;
+
+        for (int i = 0; i < rowSize; i++)
+        {
+            string[] columns = row[i].Split('\t');
+
+            string skillName = columns[0];
+            SkillData skillData = new SkillData {name = skillName, skillPower = int.Parse(columns[1]), coolTime = float.Parse(columns[2]) };
+
+            skillDataBase.AddSkillData(skillName, skillData);
         }
     }
 }

--- a/Assets/Scripts/Data/GameData/MonsterDataBase.cs
+++ b/Assets/Scripts/Data/GameData/MonsterDataBase.cs
@@ -30,4 +30,7 @@ public class MonsterData
     public int health;
     public int damage;
     public float speed;
+    public int dropGold;
+    public int dropExp;
+    public float range;
 }

--- a/Assets/Scripts/Data/GameData/SkillDataBase.cs
+++ b/Assets/Scripts/Data/GameData/SkillDataBase.cs
@@ -1,0 +1,18 @@
+using StructType;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SkillDataBase : ScriptableObject
+{
+    private Dictionary<string, SkillData> skillDataDic = new Dictionary<string, SkillData>();
+
+    public void AddSkillData(string name, SkillData skillData)
+    {
+        skillDataDic.Add(name, skillData);
+    }
+    public SkillData GetSkillData(string name)
+    {
+        return skillDataDic[name];
+    }
+}

--- a/Assets/Scripts/Data/GameData/SkillDataBase.cs.meta
+++ b/Assets/Scripts/Data/GameData/SkillDataBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f5562add60c82e4e8c90646c5888db2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/PlayerStatusData.cs
+++ b/Assets/Scripts/Data/PlayerStatusData.cs
@@ -1,6 +1,7 @@
 using EnumType;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 public class PlayerStatusData
@@ -15,13 +16,17 @@ public class PlayerStatusData
     private List<int> hpModifier = new List<int>();
 
     private int _curHP;
-    public int curHP { get => _curHP; set { _curHP = value; OnHPChanged?.Invoke(_curHP); } }
+    public int curHP { get => _curHP; private set { _curHP = value; OnHPChanged?.Invoke(_curHP); } }
 
     private int _curExp;
-    public int curExp { get => curExp; set { _curExp = value; OnExpChanged?.Invoke(_curExp); } }
+    public int curExp { get => curExp; private set { _curExp = value; OnExpChanged?.Invoke(_curExp); } }
+
+    private int _level;
+    public int level { get => _level; private set { _level = value; OnLevelUp?.Invoke(_level); } }
 
     public event Action<int> OnHPChanged;
     public event Action<int> OnExpChanged;
+    public event Action<int> OnLevelUp;
 
     public PlayerLevelData levelExpData = ScriptableObject.CreateInstance<PlayerLevelData>();
 
@@ -44,5 +49,31 @@ public class PlayerStatusData
             case StatType.MaxHP:
                 hpModifier.Remove(amount); break;
         }
+    }
+
+    public void IncreaseHealth(int amount)
+    {
+        curHP += amount;
+
+        if(curHP > maxHP)
+            curHP = maxHP;
+    }
+    public void AddExp(int amount)
+    {
+        curExp += Mathf.RoundToInt((UnityEngine.Random.Range(amount * 0.8f, amount * 1.2f)));
+
+        CheckLevelUp();
+    }
+
+    private void CheckLevelUp() // 임시로 여기 두었음 바꿀 수도 있음.
+    {
+        if(curExp >= levelExpData.GetLevelExp(level))
+        {
+            LevelUp();    
+        }
+    }
+    private void LevelUp()
+    {
+        level++;
     }
 }

--- a/Assets/Scripts/Managers/DataManager.cs
+++ b/Assets/Scripts/Managers/DataManager.cs
@@ -6,12 +6,14 @@ public class DataManager : Singleton<DataManager>
     
     public MonsterDataBase monsterData;
     public PlayerStatusData playerStatus;
+    public SkillDataBase skillData;
 
     public Inventory inventory;
 
     private void Awake()
     {
         monsterData = ScriptableObject.CreateInstance<MonsterDataBase>();
+        skillData = ScriptableObject.CreateInstance<SkillDataBase>();
         playerStatus = new PlayerStatusData();
         inventory = new GameObject("Inventory").AddComponent<Inventory>();
 
@@ -21,7 +23,6 @@ public class DataManager : Singleton<DataManager>
     private void Start()
     {
         dataSetter.Init();
-
         Destroy(dataSetter, 5);
     }
 }

--- a/Assets/Scripts/Types/EnumType.cs
+++ b/Assets/Scripts/Types/EnumType.cs
@@ -2,7 +2,7 @@ namespace EnumType
 {
     public enum SoundType { BGM, Effect }
     public enum MonsterType { Goblin, Orc, Slime }
-    public enum DataType { Pool, Monster, Level }
+    public enum DataType { Pool, Monster, Level, Skill }
     public enum ItemGrade { Common, UnCommon, Rare, Epic, Unique, Legendary }
     public enum EquipmentType { Waepon }
     public enum StatType { Damage, MaxHP }

--- a/Assets/Scripts/Types/StructType.cs
+++ b/Assets/Scripts/Types/StructType.cs
@@ -17,6 +17,14 @@ namespace StructType
         public Material material;
     }
 
+    [Serializable]
+    public struct SkillData
+    {
+        public string name;
+        public int skillPower;
+        public float coolTime;
+    }
+
     public struct SkillVector
     {
         public Vector3 forward;


### PR DESCRIPTION
몬스터는 골드, 경험치, 감지범위를 추가하고
스킬데이터는 이름, 데미지, 쿨타임을 가지고 있다.

그리고 PlayerStatus의 curHP와 curExp를 외부에서 수정이 가능하였어서 막고

함수로 변경할 수 있도록 하였다.

그리고 Level데이터를 추가 하였다.